### PR TITLE
Update install instructions and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo docker login nvcr.io
 ```
 Next, clone this repo using:
 ```
-git clone https://gitlab-master.nvidia.com/srl/motion-policy-networks
+git clone https://github.com/NVlabs/motion-policy-networks.git
 ```
 Navigate inside the repo (e.g. `cd motion-policy-networks`) and build the docker with
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ either inside the docker or on the host machine.
 All usage described below must happen inside the docker container. For all the commands below,
 assume that they should be run inside the docker container.
 
+In order to easily import mpinets as a module in our python scripts, we first install it in developer mode as follows:
+```
+pip install -e .
+```
+
 ## Inference With Motion Policy Networks
 
 In order to run inference, you will need a pretrained model file. This will be

--- a/interactive_demo/mpinets_msgs/package.xml
+++ b/interactive_demo/mpinets_msgs/package.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>mpinets_msgs</name>
+  <maintainer email="someone@mail.com">Someone</maintainer>
   <version>0.0.0</version>
   <description>The mpinets_msgs package</description>
   <license>MIT</license>

--- a/interactive_demo/mpinets_ros/launch/visualize.launch
+++ b/interactive_demo/mpinets_ros/launch/visualize.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="mdl_path" />
   <arg name="point_cloud_path" />
-  <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=1" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda/panda.urdf.xacro hand:=true" />
   <node pkg="mpinets_ros" type="planning_node.py" name="mpinets_planning_node" output="screen" clear_params="true">
     <param name="mdl_path" value="$(arg mdl_path)" />
     <param name="point_cloud_path" value="$(arg point_cloud_path)" />


### PR DESCRIPTION
The installation instructions seem to be a bit out of date.

- The `mpinets_msgs` ROS package config was missing a necessary `maintainer` tag.
- Franka modified their `franka_description` package, so the path to the panda xacro and the way to call it had to be updated.
- A step was missing in the Usage section of the README to pip install `mpinets` in developer mode before importing it in scripts.
- The link to the motion-policy-networks repo was updated from gitlab to github.